### PR TITLE
Fix workflow publish container

### DIFF
--- a/.github/workflows/webapp-publish-on-relaese.yml
+++ b/.github/workflows/webapp-publish-on-relaese.yml
@@ -15,7 +15,7 @@ jobs:
             - name: Checkout the repo # (callout-1)
               uses: actions/checkout@v2
             - name: Build image # (callout-2)
-              run: docker build -t versale-back .
+              run: docker build -t versale-front .
             - name: Install doctl # (callout-3)
               uses: digitalocean/action-doctl@v2
               with:


### PR DESCRIPTION

### Pull Request Description

#### Overview

This pull request includes several updates to the existing GitHub Actions workflow, which are intended to streamline the build and deployment process. The changes focus on modifying the Docker image build command.

#### Changes Made

1.  **Checkout the Repository**:
    
    -   **Action**: `actions/checkout@v2`
    -   **Purpose**: This step ensures that the latest version of the repository is checked out and available for the workflow to use.
2.  **Build Image**:
    
    -   **Original Command**: `docker build -t versale-back .`
    -   **Updated Command**: `docker build -t versale-front .`
    -   **Purpose**: This change updates the Docker image build tag from `versale-back` to `versale-front`. This adjustment is likely aimed at building a frontend service image instead of a backend service image.
3.  **Install doctl**:
    
    -   **Action**: `digitalocean/action-doctl@v2`
    -   **Purpose**: This step installs `doctl`, the official DigitalOcean command line tool, which will be used in subsequent steps for interacting with DigitalOcean resources.

#### Impact

-   **Docker Image Tag**: Changing the Docker image tag impacts how the built image is labeled and identified. This is particularly important for ensuring the correct image is used in subsequent deployment steps.
-   **Workflow Consistency**: Ensuring that the correct version of `doctl` is installed guarantees that the workflow remains consistent and functions as expected when interacting with DigitalOcean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the Docker build process to correctly build the front-end image for web app releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->